### PR TITLE
修改防止download依赖content-length

### DIFF
--- a/amiyabot/network/download.py
+++ b/amiyabot/network/download.py
@@ -18,17 +18,13 @@ def download_sync(url: str, headers=None, stringify=False, progress=False):
 
     try:
         stream = requests.get(url, headers=headers or default_headers, stream=True)
-        file_size = 0
-        if 'content-length' in stream.headers:
-            file_size = int(stream.headers['content-length'])
-
         container = BytesIO()
 
         if stream.status_code == 200:
             iter_content = stream.iter_content(chunk_size=1024)
-            if progress:
+            if progress and 'content-length' in stream.headers:
                 iter_content = log.download_progress(url.split('/')[-1],
-                                                     max_size=file_size,
+                                                     max_size=int(stream.headers['content-length']),
                                                      chunk_size=1024,
                                                      iter_content=iter_content)
             for chunk in iter_content:

--- a/amiyabot/network/download.py
+++ b/amiyabot/network/download.py
@@ -18,7 +18,9 @@ def download_sync(url: str, headers=None, stringify=False, progress=False):
 
     try:
         stream = requests.get(url, headers=headers or default_headers, stream=True)
-        file_size = int(stream.headers['content-length'])
+        file_size = 0
+        if 'content-length' in stream.headers:
+            file_size = int(stream.headers['content-length'])
 
         container = BytesIO()
 


### PR DESCRIPTION
原先的download sync函数里，依赖header包含content-length，如果没有就会报错
但是有很多下载服务不支持提供content-length的

比如企鹅物流的matrix下载就不支持

因此建议是去掉这个限制，有提供就用，没有也不报错