### PR TITLE
使用代理

### DIFF
--- a/amiyabot/network/download.py
+++ b/amiyabot/network/download.py
@@ -39,7 +39,7 @@ def download_sync(url: str, headers=None, stringify=False, progress=False, **kwa
 
 async def download_async(url, headers=None, stringify=False, **kwargs):
     async with log.catch('download error:', ignore=[requests.exceptions.SSLError]):
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(url, headers={**default_headers, **(headers or {})}, **kwargs) as res:
                 if res.status == 200:
                     if stringify:


### PR DESCRIPTION
和requests不同，aiohttp不会默认使用环境变量中给出的proxy
下面是官方文档
https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support

因此这里需要使用这个命令手动应用可能的环境变量。
不然，sync和async的代理响应不一样不是很怪吗？

我研究了一整天的网络问题，最后无奈使用代理，结果发现core对代理的支持还有问题......