### PR TITLE
修改消息钩子

### DIFF
--- a/amiyabot/handler/messageHandler.py
+++ b/amiyabot/handler/messageHandler.py
@@ -34,13 +34,13 @@ async def message_handler(bot: BotHandlerFactory, data: Union[Message, Event, Ev
     # todo 生命周期 - message_created
     for method in bot.process_message_created:
         method_ret = await method(data, instance)
-        
+
         if method_ret is False:
             return None
-    
+
         if method_ret is not None:
             data = method_ret
-    
+
     # 检查是否存在等待事件
     waiter = await find_wait_event(data)
 

--- a/amiyabot/handler/messageHandler.py
+++ b/amiyabot/handler/messageHandler.py
@@ -33,8 +33,14 @@ async def message_handler(bot: BotHandlerFactory, data: Union[Message, Event, Ev
 
     # todo 生命周期 - message_created
     for method in bot.process_message_created:
-        data = await method(data, instance) or data
-
+        method_ret = await method(data, instance)
+        
+        if method_ret is False:
+            return None
+    
+        if method_ret is not None:
+            data = method_ret
+    
     # 检查是否存在等待事件
     waiter = await find_wait_event(data)
 


### PR DESCRIPTION
这个PR修改了message_created钩子的行为，如果他显式返回False，则可以打断消息处理。

建议将这个内容更新到教程，因为这个函数的行为发生变化了。
以前如果这个函数返回False的话，是data不变继续执行，也许有插件作者就返回了False呢。

修改这个的目的是为了提供一个更加靠前的消息钩子。
现有的钩子无法在wait函数事件之前相应。
所以我做的“全局拉黑”插件，没办法在做游戏的时候生效。